### PR TITLE
Added layout contexts for Whale, Playground & Network

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -146,7 +146,6 @@
       <w>numnotequal</w>
       <w>onboarding</w>
       <w>paytxfee</w>
-      <w>playgroundlocal</w>
       <w>pooledtx</w>
       <w>poolpair</w>
       <w>poolpairs</w>

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -146,6 +146,7 @@
       <w>numnotequal</w>
       <w>onboarding</w>
       <w>paytxfee</w>
+      <w>playgroundlocal</w>
       <w>pooledtx</w>
       <w>poolpair</w>
       <w>poolpairs</w>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,5 @@
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
+
+[context.deploy-preview.environment]
+ENVIRONMENT_NAME = "preview"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,2 @@
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
-
-[context.deploy-preview.environment]
-ENVIRONMENT_NAME = "preview"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[plugins]]
+package = "@netlify/plugin-lighthouse"
+
+[context.deploy-preview.environment]
+NODE_ENV = "test"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,2 @@
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
-
-[context.deploy-preview.environment]
-NODE_ENV = "test"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@defichain/playground-api-client": "^0.5.5",
+        "@defichain/whale-api-client": ">=0.5.8",
         "next": "11.0.1",
         "react": "17.0.2",
         "react-dom": "17.0.2"
@@ -80,6 +82,47 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@defichain/jellyfish-api-core": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.26.0.tgz",
+      "integrity": "sha512-7AmhsZCzofqYFGMflTdtbP/LrQWMbPO9H+n07jFpXRIqfw5dFEoHVZrUS37YGRS6l5l3MsI90YA1NeiAXghzjw==",
+      "dependencies": {
+        "@defichain/jellyfish-json": "^0.26.0"
+      }
+    },
+    "node_modules/@defichain/jellyfish-json": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.26.0.tgz",
+      "integrity": "sha512-T9nZamURkIoQMV3fpibnzIpEmrVzK2Qj0w2CxldDxZ+/qrUs2MixTeBRTr+OHQth3vldnnD1jBZrzhk5cN+HNg==",
+      "dependencies": {
+        "@types/lossless-json": "^1.0.1",
+        "lossless-json": "^1.0.4"
+      },
+      "peerDependencies": {
+        "bignumber.js": "^9.0.1"
+      }
+    },
+    "node_modules/@defichain/playground-api-client": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.5.5.tgz",
+      "integrity": "sha512-e7cadcYECWKrHtpo5zC3zLzMQrwzda6IbD4KcWetWGUszjPtcfFFIhvc0yld9o7+2jEoxQcItTButBW9isq5hg==",
+      "dependencies": {
+        "@defichain/jellyfish-api-core": ">=0.26.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.2"
+      }
+    },
+    "node_modules/@defichain/whale-api-client": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.5.8.tgz",
+      "integrity": "sha512-B3a9IQf8e5FbzYNvmvSBPw93M/4XKHwWAgouCN9vbzwXrmIxaRJhNipv2KUpNZQDdRKBZaSLFC+g+kDgXmmWoQ==",
+      "dependencies": {
+        "@defichain/jellyfish-api-core": ">=0.26.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.2",
+        "url-search-params-polyfill": "8.1.1"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -365,6 +408,11 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "node_modules/@types/lossless-json": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/lossless-json/-/lossless-json-1.0.1.tgz",
+      "integrity": "sha512-zPE8kmpeL5/6L5gtTQHSOkAW/OSYYNTDRt6/2oEgLO1Zd3Rj5WVDoMloTtLJxQJhZGLGbL4pktKSh3NbzdaWdw=="
+    },
     "node_modules/@types/node": {
       "version": "14.17.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
@@ -559,6 +607,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/acorn": {
@@ -891,6 +950,15 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -1277,6 +1345,14 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dependencies": {
+        "node-fetch": "2.6.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -2354,6 +2430,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3403,6 +3487,11 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/lossless-json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.4.tgz",
+      "integrity": "sha512-zEkWwELMSQQISdtOF44vk0bRJhN/PJ93qcgJLcodizQjxrJKdFrq2H1+Xv5QDe7v3dTYYbBI5hOsh4a9l0B2Ow=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -5794,6 +5883,11 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/url-search-params-polyfill": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz",
+      "integrity": "sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q=="
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -6036,6 +6130,44 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@defichain/jellyfish-api-core": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.26.0.tgz",
+      "integrity": "sha512-7AmhsZCzofqYFGMflTdtbP/LrQWMbPO9H+n07jFpXRIqfw5dFEoHVZrUS37YGRS6l5l3MsI90YA1NeiAXghzjw==",
+      "requires": {
+        "@defichain/jellyfish-json": "^0.26.0"
+      }
+    },
+    "@defichain/jellyfish-json": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.26.0.tgz",
+      "integrity": "sha512-T9nZamURkIoQMV3fpibnzIpEmrVzK2Qj0w2CxldDxZ+/qrUs2MixTeBRTr+OHQth3vldnnD1jBZrzhk5cN+HNg==",
+      "requires": {
+        "@types/lossless-json": "^1.0.1",
+        "lossless-json": "^1.0.4"
+      }
+    },
+    "@defichain/playground-api-client": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.5.5.tgz",
+      "integrity": "sha512-e7cadcYECWKrHtpo5zC3zLzMQrwzda6IbD4KcWetWGUszjPtcfFFIhvc0yld9o7+2jEoxQcItTButBW9isq5hg==",
+      "requires": {
+        "@defichain/jellyfish-api-core": ">=0.26.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.2"
+      }
+    },
+    "@defichain/whale-api-client": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.5.8.tgz",
+      "integrity": "sha512-B3a9IQf8e5FbzYNvmvSBPw93M/4XKHwWAgouCN9vbzwXrmIxaRJhNipv2KUpNZQDdRKBZaSLFC+g+kDgXmmWoQ==",
+      "requires": {
+        "@defichain/jellyfish-api-core": ">=0.26.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.2",
+        "url-search-params-polyfill": "8.1.1"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
@@ -6258,6 +6390,11 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/lossless-json": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/lossless-json/-/lossless-json-1.0.1.tgz",
+      "integrity": "sha512-zPE8kmpeL5/6L5gtTQHSOkAW/OSYYNTDRt6/2oEgLO1Zd3Rj5WVDoMloTtLJxQJhZGLGbL4pktKSh3NbzdaWdw=="
+    },
     "@types/node": {
       "version": "14.17.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
@@ -6386,6 +6523,14 @@
       "requires": {
         "@typescript-eslint/types": "4.26.0",
         "eslint-visitor-keys": "^2.0.0"
+      }
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
       }
     },
     "acorn": {
@@ -6627,6 +6772,12 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "peer": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -6966,6 +7117,14 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -7800,6 +7959,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -8569,6 +8733,11 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lossless-json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.4.tgz",
+      "integrity": "sha512-zEkWwELMSQQISdtOF44vk0bRJhN/PJ93qcgJLcodizQjxrJKdFrq2H1+Xv5QDe7v3dTYYbBI5hOsh4a9l0B2Ow=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -10419,6 +10588,11 @@
           "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         }
       }
+    },
+    "url-search-params-polyfill": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz",
+      "integrity": "sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q=="
     },
     "use-subscription": {
       "version": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@defichain/playground-api-client": "^0.5.5",
         "@defichain/whale-api-client": ">=0.5.8",
+        "bignumber.js": "^9.0.1",
         "next": "11.0.1",
         "react": "17.0.2",
         "react-dom": "17.0.2"
@@ -958,7 +959,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6776,8 +6776,7 @@
     "bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "peer": true
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@defichain/playground-api-client": "^0.5.5",
     "@defichain/whale-api-client": ">=0.5.8",
+    "bignumber.js": "^9.0.1",
     "next": "11.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "start": "next start"
   },
   "dependencies": {
+    "@defichain/playground-api-client": "^0.5.5",
+    "@defichain/whale-api-client": ">=0.5.8",
     "next": "11.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Disallow: /*?network=*

--- a/src/components/icons/DeFiChainLogo.tsx
+++ b/src/components/icons/DeFiChainLogo.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import { SVGProps } from "react";
 
-export default function DeFiChainLogo (props: React.SVGProps<SVGSVGElement>): JSX.Element {
+export default function DeFiChainLogo (props: SVGProps<SVGSVGElement>): JSX.Element {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={156} height={72} viewBox={'0 0 156 72'} {...props}>
       <path

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import { PropsWithChildren } from "react";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
+import { useKeepNetworkQueryString } from "./contexts/api/NetworkQuery";
 import { NetworkProvider } from "./contexts/NetworkContext";
 import { PlaygroundProvider } from "./contexts/PlaygroundContext";
 import { WhaleProvider } from "./contexts/WhaleContext";
@@ -14,6 +15,8 @@ import { WhaleProvider } from "./contexts/WhaleContext";
  * Finally with <WhaleProvider> to provide WhaleContext for accessing of WhaleAPI and WhaleRPC.
  */
 export default function Default (props: PropsWithChildren<any>): JSX.Element | null {
+  useKeepNetworkQueryString()
+
   return (
     <div className={'flex flex-col min-h-screen'}>
       <Head>

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,9 +1,19 @@
-import React from 'react'
 import Head from "next/head";
+import React from 'react'
 import Footer from "./components/Footer";
 import Header from "./components/Header";
+import { NetworkProvider } from "./contexts/NetworkContext";
+import { PlaygroundProvider } from "./contexts/PlaygroundContext";
+import { WhaleProvider } from "./contexts/WhaleContext";
 
-export default function Default (props: React.PropsWithChildren<any>): JSX.Element {
+/**
+ * Default Layout with <Head> providing default Metadata for SEO
+ *
+ * Wrapped in <NetworkProvider> intercept network params from querystring.
+ * Followed by <PlaygroundProvider> to automatically swatch between local and remote playground for debug environment.
+ * Finally with <WhaleProvider> to provide WhaleContext for accessing of WhaleAPI and WhaleRPC.
+ */
+export default function Default (props: React.PropsWithChildren<any>): JSX.Element | null {
   return (
     <div className={'flex flex-col min-h-screen'}>
       <Head>
@@ -12,13 +22,19 @@ export default function Default (props: React.PropsWithChildren<any>): JSX.Eleme
         <link rel='icon' href='/favicon.ico' />
       </Head>
 
-      <Header />
+      <NetworkProvider>
+        <PlaygroundProvider>
+          <WhaleProvider>
+            <Header />
 
-      <main className={'flex-grow'}>
-        {props.children}
-      </main>
+            <main className={'flex-grow'}>
+              {props.children}
+            </main>
 
-      <Footer />
+            <Footer />
+          </WhaleProvider>
+        </PlaygroundProvider>
+      </NetworkProvider>
     </div>
   )
 }

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import React from 'react'
+import { PropsWithChildren } from "react";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
 import { NetworkProvider } from "./contexts/NetworkContext";
@@ -13,7 +13,7 @@ import { WhaleProvider } from "./contexts/WhaleContext";
  * Followed by <PlaygroundProvider> to automatically swatch between local and remote playground for debug environment.
  * Finally with <WhaleProvider> to provide WhaleContext for accessing of WhaleAPI and WhaleRPC.
  */
-export default function Default (props: React.PropsWithChildren<any>): JSX.Element | null {
+export default function Default (props: PropsWithChildren<any>): JSX.Element | null {
   return (
     <div className={'flex flex-col min-h-screen'}>
       <Head>

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -6,7 +6,9 @@ export default function Footer (): JSX.Element {
     <footer className={'mt-12 border-t border-gray-100'}>
       <div className={'container mx-auto px-4 py-12'}>
         <Link href={'/'}>
-          <DeFiChainLogo className={'w-28 h-full cursor-pointer'} />
+          <div className={'cursor-pointer'}>
+            <DeFiChainLogo className={'w-28 h-full'} />
+          </div>
         </Link>
 
         <div className={'flex flex-wrap mt-4'}>

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -3,14 +3,14 @@ import DeFiChainLogo from "../../components/icons/DeFiChainLogo";
 
 export default function Footer (): JSX.Element {
   return (
-    <footer className={'mt-12'}>
+    <footer className={'mt-12 border-t border-gray-100'}>
       <div className={'container mx-auto px-4 py-12'}>
         <Link href={'/'}>
           <DeFiChainLogo className={'w-28 h-full cursor-pointer'} />
         </Link>
 
-        <div className={'flex flex-wrap mt-4 -mx-8'}>
-          <div className={'px-8 py-3 flex-grow'}>
+        <div className={'flex flex-wrap mt-4'}>
+          <div className={'py-3 flex-grow'}>
             <div className={'text-2xl font-semibold'}>Explorer</div>
 
             <div className={'flex flex-wrap mt-3 -m-2 w-72'}>
@@ -22,7 +22,7 @@ export default function Footer (): JSX.Element {
             </div>
           </div>
 
-          <div className={'px-8 py-3 max-w-lg'}>
+          <div className={'py-3 max-w-lg'}>
             <p className={'text-sm text-gray-600'}>
               DeFi Blockchain’s primary vision is to enable decentralized finance with Bitcoin-grade security, strength
               and immutability. It's a blockchain dedicated to fast, intelligent and transparent financial services,

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from 'next/link'
 import DeFiChainLogo from "../../components/icons/DeFiChainLogo";
 

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -1,8 +1,22 @@
 import Link from "next/link";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import DeFiChainLogo from "../../components/icons/DeFiChainLogo";
+import { getEnvironment } from "../contexts/api/Environment";
+import { useNetworkContext } from "../contexts/NetworkContext";
+import { useWhaleRpcClient } from "../contexts/WhaleContext";
 
 export default function Header (): JSX.Element {
+  const { network } = useNetworkContext()
+  const rpc = useWhaleRpcClient()
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    // Temporary Implementation Example Only
+    rpc.blockchain.getBlockchainInfo().then(({ blocks }) => {
+      setCount(blocks)
+    })
+  }, [network]);
+
   return (
     <header className={'bg-white'}>
       <div className={'border-b border-gray-100'}>
@@ -11,15 +25,18 @@ export default function Header (): JSX.Element {
             <div>
               <div>
                 <ul className={'text-xs'}>
-                  <li>Blocks: <span className={'text-primary font-medium'}>999,999</span></li>
+                  <li>Blocks: <span className={'text-primary font-medium'}>{count}</span></li>
                 </ul>
               </div>
             </div>
-            <div>
-              <button className={'text-xs font-medium bg-gray-100 px-2 py-1 rounded flex items-center'}>
+            <div className={'flex items-center'}>
+              <div className={'mr-3 text-sm font-medium'}>
+                {getEnvironment().name}
+              </div>
+              <button className={'bg-gray-100 px-2 py-1.5 rounded flex items-center'}>
                 <div className={'bg-green-500 h-1.5 w-1.5 rounded-full'} />
-                <div className={'ml-2'}>
-                  MainNet
+                <div className={'text-xs ml-2 font-semibold'}>
+                  {network}
                 </div>
               </button>
             </div>
@@ -31,8 +48,8 @@ export default function Header (): JSX.Element {
         <div className={'container mx-auto px-4 py-8'}>
           <div className={'flex items-center'}>
             <Link href={'/'}>
-              <div className={'flex items-center'}>
-                <DeFiChainLogo className={'w-16 h-full cursor-pointer'} />
+              <div className={'flex items-center cursor-pointer hover:text-primary'}>
+                <DeFiChainLogo className={'w-16 h-full'} />
                 <h6 className={'ml-3 text-md font-semibold'}>Explorer</h6>
               </div>
             </Link>

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -20,7 +20,7 @@ export default function Header (): JSX.Element {
   return (
     <header className={'bg-white'}>
       <div className={'border-b border-gray-100'}>
-        <div className={'container mx-auto px-4 py-1'}>
+        <div className={'container mx-auto px-4 py-1.5'}>
           <div className={'flex items-center justify-between'}>
             <div>
               <div>

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -30,7 +30,7 @@ export default function Header (): JSX.Element {
               </div>
             </div>
             <div className={'flex items-center'}>
-              <div className={'mr-3 text-sm font-medium'}>
+              <div className={'mr-3 text-xs font-medium'}>
                 {getEnvironment().name}
               </div>
               <button className={'bg-gray-100 px-2 py-1.5 rounded flex items-center'}>

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import DeFiChainLogo from "../../components/icons/DeFiChainLogo";
 import { getEnvironment } from "../contexts/api/Environment";
 import { useNetworkContext } from "../contexts/NetworkContext";

--- a/src/layouts/contexts/NetworkContext.tsx
+++ b/src/layouts/contexts/NetworkContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState } from 'react'
+import { EnvironmentNetwork } from "./api/Environment";
+import { useNetworkQuery } from "./api/NetworkQuery";
+
+interface Network {
+  network: EnvironmentNetwork
+  setNetwork: (network: EnvironmentNetwork) => void
+}
+
+const NetworkContext = createContext<Network>(undefined as any)
+
+export function useNetworkContext (): Network {
+  return useContext(NetworkContext)
+}
+
+export function NetworkProvider (props: React.PropsWithChildren<any>): JSX.Element | null {
+  const query = useNetworkQuery()
+  const [network, setNetwork] = useState<EnvironmentNetwork>(query.getNetwork())
+
+  const context: Network = {
+    network: network,
+    setNetwork (value: EnvironmentNetwork): void {
+      query.setNetwork(value)
+      setNetwork(value)
+    }
+  }
+
+  return (
+    <NetworkContext.Provider value={context}>
+      {props.children}
+    </NetworkContext.Provider>
+  )
+}

--- a/src/layouts/contexts/NetworkContext.tsx
+++ b/src/layouts/contexts/NetworkContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react'
+import { createContext, PropsWithChildren, useContext, useState } from 'react'
 import { EnvironmentNetwork } from "./api/Environment";
 import { useNetworkQuery } from "./api/NetworkQuery";
 
@@ -13,7 +13,7 @@ export function useNetworkContext (): Network {
   return useContext(NetworkContext)
 }
 
-export function NetworkProvider (props: React.PropsWithChildren<any>): JSX.Element | null {
+export function NetworkProvider (props: PropsWithChildren<any>): JSX.Element | null {
   const query = useNetworkQuery()
   const [network, setNetwork] = useState<EnvironmentNetwork>(query.getNetwork())
 

--- a/src/layouts/contexts/PlaygroundContext.tsx
+++ b/src/layouts/contexts/PlaygroundContext.tsx
@@ -1,0 +1,88 @@
+import { PlaygroundApiClient, PlaygroundRpcClient } from '@defichain/playground-api-client'
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { EnvironmentNetwork, getEnvironment, isPlayground } from "./api/Environment";
+import { useNetworkContext } from './NetworkContext'
+
+interface Playground {
+  rpc: PlaygroundRpcClient
+  api: PlaygroundApiClient
+}
+
+const PlaygroundContext = createContext<Playground>(undefined as any)
+
+/**
+ * usePlaygroundContext(), only available in debug mode and playground network.
+ */
+export function usePlaygroundContext (): Playground {
+  return useContext(PlaygroundContext)
+}
+
+export function PlaygroundProvider (props: React.PropsWithChildren<any>): JSX.Element | null {
+  const { network } = useNetworkContext()
+
+  const connected = useConnectedPlayground()
+
+  const context = useMemo(() => {
+    const api = newPlaygroundClient(network)
+    const rpc = new PlaygroundRpcClient(api)
+    return { api, rpc }
+  }, [network])
+
+  if (!connected) {
+    return null
+  }
+
+  return (
+    <PlaygroundContext.Provider value={context}>
+      {props.children}
+    </PlaygroundContext.Provider>
+  )
+}
+
+/**
+ * hooks to find connected playground
+ * @return boolean when completed or found connected playground
+ */
+function useConnectedPlayground (): boolean {
+  const { setNetwork } = useNetworkContext()
+  const [isLoaded, setLoaded] = useState(false)
+
+  const environment = getEnvironment()
+  if (!environment.debug) {
+    return true
+  }
+
+  useEffect(() => {
+    async function findPlayground (): Promise<void> {
+      for (const network of environment.networks.filter(isPlayground)) {
+        if (await isConnected(network)) {
+          setNetwork(network)
+          setLoaded(true)
+          return
+        }
+      }
+    }
+
+    void findPlayground()
+  }, [])
+
+  return isLoaded
+}
+
+async function isConnected (network: EnvironmentNetwork): Promise<boolean> {
+  const client = newPlaygroundClient(network)
+  return await client.playground.info()
+    .then(() => true)
+    .catch(() => false)
+}
+
+function newPlaygroundClient (network: EnvironmentNetwork): PlaygroundApiClient {
+  switch (network) {
+    case EnvironmentNetwork.RemotePlayground:
+      return new PlaygroundApiClient({ url: 'https://playground.defichain.com' })
+    case EnvironmentNetwork.LocalPlayground:
+      return new PlaygroundApiClient({ url: 'http://localhost:19553' })
+    default:
+      throw new Error(`playground not available for '${network}'`)
+  }
+}

--- a/src/layouts/contexts/PlaygroundContext.tsx
+++ b/src/layouts/contexts/PlaygroundContext.tsx
@@ -1,5 +1,5 @@
 import { PlaygroundApiClient, PlaygroundRpcClient } from '@defichain/playground-api-client'
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react'
 import { EnvironmentNetwork, getEnvironment, isPlayground } from "./api/Environment";
 import { useNetworkContext } from './NetworkContext'
 
@@ -17,7 +17,7 @@ export function usePlaygroundContext (): Playground {
   return useContext(PlaygroundContext)
 }
 
-export function PlaygroundProvider (props: React.PropsWithChildren<any>): JSX.Element | null {
+export function PlaygroundProvider (props: PropsWithChildren<any>): JSX.Element | null {
   const { network } = useNetworkContext()
 
   const connected = useConnectedPlayground()

--- a/src/layouts/contexts/PlaygroundContext.tsx
+++ b/src/layouts/contexts/PlaygroundContext.tsx
@@ -8,21 +8,28 @@ interface Playground {
   api: PlaygroundApiClient
 }
 
-const PlaygroundContext = createContext<Playground>(undefined as any)
+const PlaygroundContext = createContext<Playground | undefined>(undefined)
 
 /**
  * usePlaygroundContext(), only available in debug mode and playground network.
  */
 export function usePlaygroundContext (): Playground {
-  return useContext(PlaygroundContext)
+  const context = useContext(PlaygroundContext)
+  if (context !== undefined) {
+    return context
+  }
+
+  throw new Error(`attempting to usePlaygroundContext on a debug environment`)
 }
 
 export function PlaygroundProvider (props: PropsWithChildren<any>): JSX.Element | null {
   const { network } = useNetworkContext()
-
   const connected = useConnectedPlayground()
 
   const context = useMemo(() => {
+    if (!getEnvironment().debug) {
+      return undefined
+    }
     const api = newPlaygroundClient(network)
     const rpc = new PlaygroundRpcClient(api)
     return { api, rpc }

--- a/src/layouts/contexts/WhaleContext.tsx
+++ b/src/layouts/contexts/WhaleContext.tsx
@@ -1,5 +1,5 @@
 import { WhaleApiClient, WhaleRpcClient } from '@defichain/whale-api-client'
-import React, { createContext, useContext, useMemo } from 'react'
+import { createContext, PropsWithChildren, useContext, useMemo } from 'react'
 import { EnvironmentNetwork } from "./api/Environment";
 import { useNetworkContext } from './NetworkContext'
 
@@ -14,7 +14,7 @@ export function useWhaleRpcClient (): WhaleRpcClient {
   return useContext(WhaleRpcClientContext)
 }
 
-export function WhaleProvider (props: React.PropsWithChildren<any>): JSX.Element | null {
+export function WhaleProvider (props: PropsWithChildren<any>): JSX.Element | null {
   const { network } = useNetworkContext()
 
   const { api, rpc } = useMemo(() => {

--- a/src/layouts/contexts/WhaleContext.tsx
+++ b/src/layouts/contexts/WhaleContext.tsx
@@ -1,0 +1,46 @@
+import { WhaleApiClient, WhaleRpcClient } from '@defichain/whale-api-client'
+import React, { createContext, useContext, useMemo } from 'react'
+import { EnvironmentNetwork } from "./api/Environment";
+import { useNetworkContext } from './NetworkContext'
+
+const WhaleApiClientContext = createContext<WhaleApiClient>(undefined as any)
+const WhaleRpcClientContext = createContext<WhaleRpcClient>(undefined as any)
+
+export function useWhaleApiClient (): WhaleApiClient {
+  return useContext(WhaleApiClientContext)
+}
+
+export function useWhaleRpcClient (): WhaleRpcClient {
+  return useContext(WhaleRpcClientContext)
+}
+
+export function WhaleProvider (props: React.PropsWithChildren<any>): JSX.Element | null {
+  const { network } = useNetworkContext()
+
+  const { api, rpc } = useMemo(() => {
+    const api = newWhaleClient(network)
+    const rpc = new WhaleRpcClient(api)
+    return { api, rpc }
+  }, [network])
+
+  return (
+    <WhaleApiClientContext.Provider value={api}>
+      <WhaleRpcClientContext.Provider value={rpc}>
+        {props.children}
+      </WhaleRpcClientContext.Provider>
+    </WhaleApiClientContext.Provider>
+  )
+}
+
+function newWhaleClient (network: EnvironmentNetwork): WhaleApiClient {
+  switch (network) {
+    case EnvironmentNetwork.MainNet:
+      return new WhaleApiClient({ url: 'https://ocean.defichain.com', network: 'mainnet' })
+    case EnvironmentNetwork.TestNet:
+      return new WhaleApiClient({ url: 'https://ocean.defichain.com', network: 'testnet' })
+    case EnvironmentNetwork.RemotePlayground:
+      return new WhaleApiClient({ url: 'https://playground.defichain.com', network: 'regtest' })
+    case EnvironmentNetwork.LocalPlayground:
+      return new WhaleApiClient({ url: 'http://localhost:19553', network: 'regtest' })
+  }
+}

--- a/src/layouts/contexts/api/Environment.ts
+++ b/src/layouts/contexts/api/Environment.ts
@@ -1,0 +1,77 @@
+/**
+ * Network supported in this environment
+ */
+export enum EnvironmentNetwork {
+  LocalPlayground = 'Local',
+  RemotePlayground = 'Playground',
+  MainNet = 'MainNet',
+  TestNet = 'TestNet'
+}
+
+export enum EnvironmentName {
+  Production = 'Production',
+  Preview = 'Preview',
+  Development = 'Development',
+}
+
+interface Environment {
+  name: EnvironmentName
+  debug: boolean
+  networks: EnvironmentNetwork[]
+}
+
+export const environments: Record<EnvironmentName, Environment> = {
+  Production: {
+    name: EnvironmentName.Production,
+    debug: false,
+    networks: [
+      EnvironmentNetwork.MainNet,
+      EnvironmentNetwork.TestNet,
+      EnvironmentNetwork.RemotePlayground,
+    ]
+  },
+  Preview: {
+    name: EnvironmentName.Preview,
+    debug: true,
+    networks: [
+      EnvironmentNetwork.RemotePlayground,
+      EnvironmentNetwork.TestNet,
+      EnvironmentNetwork.MainNet,
+    ]
+  },
+  Development: {
+    name: EnvironmentName.Development,
+    debug: true,
+    networks: [
+      EnvironmentNetwork.LocalPlayground,
+      EnvironmentNetwork.RemotePlayground,
+      EnvironmentNetwork.TestNet,
+      EnvironmentNetwork.MainNet,
+    ]
+  }
+}
+
+/**
+ * @return Environment of current explorer setup, checked against Environment Variable
+ */
+export function getEnvironment (): Environment {
+  switch (process.env.NODE_ENV) {
+    case 'production':
+      return environments[EnvironmentName.Production]
+    case 'test':
+      return environments[EnvironmentName.Preview]
+    case 'development':
+    default:
+      return environments[EnvironmentName.Development]
+  }
+}
+
+/**
+ * @param {EnvironmentNetwork} network to check if it is a playground network
+ */
+export function isPlayground (network: EnvironmentNetwork): boolean {
+  return [
+    EnvironmentNetwork.LocalPlayground,
+    EnvironmentNetwork.RemotePlayground
+  ].includes(network)
+}

--- a/src/layouts/contexts/api/Environment.ts
+++ b/src/layouts/contexts/api/Environment.ts
@@ -55,10 +55,10 @@ export const environments: Record<EnvironmentName, Environment> = {
  * @return Environment of current explorer setup, checked against Environment Variable
  */
 export function getEnvironment (): Environment {
-  switch (process.env.NODE_ENV) {
+  switch (process.env.NODE_ENV as string) {
     case 'production':
       return environments[EnvironmentName.Production]
-    case 'test':
+    case 'preview':
       return environments[EnvironmentName.Preview]
     case 'development':
     default:

--- a/src/layouts/contexts/api/Environment.ts
+++ b/src/layouts/contexts/api/Environment.ts
@@ -55,7 +55,7 @@ export const environments: Record<EnvironmentName, Environment> = {
  * @return Environment of current explorer setup, checked against Environment Variable
  */
 export function getEnvironment (): Environment {
-  switch (process.env.NODE_ENV as string) {
+  switch (process.env.ENVIRONMENT_NAME ?? process.env.NODE_ENV) {
     case 'production':
       return environments[EnvironmentName.Production]
     case 'preview':

--- a/src/layouts/contexts/api/Environment.ts
+++ b/src/layouts/contexts/api/Environment.ts
@@ -10,7 +10,6 @@ export enum EnvironmentNetwork {
 
 export enum EnvironmentName {
   Production = 'Production',
-  Preview = 'Preview',
   Development = 'Development',
 }
 
@@ -30,15 +29,6 @@ export const environments: Record<EnvironmentName, Environment> = {
       EnvironmentNetwork.RemotePlayground,
     ]
   },
-  Preview: {
-    name: EnvironmentName.Preview,
-    debug: true,
-    networks: [
-      EnvironmentNetwork.RemotePlayground,
-      EnvironmentNetwork.TestNet,
-      EnvironmentNetwork.MainNet,
-    ]
-  },
   Development: {
     name: EnvironmentName.Development,
     debug: true,
@@ -55,11 +45,9 @@ export const environments: Record<EnvironmentName, Environment> = {
  * @return Environment of current explorer setup, checked against Environment Variable
  */
 export function getEnvironment (): Environment {
-  switch (process.env.ENVIRONMENT_NAME ?? process.env.NODE_ENV) {
+  switch (process.env.NODE_ENV) {
     case 'production':
       return environments[EnvironmentName.Production]
-    case 'preview':
-      return environments[EnvironmentName.Preview]
     case 'development':
     default:
       return environments[EnvironmentName.Development]

--- a/src/layouts/contexts/api/NetworkQuery.ts
+++ b/src/layouts/contexts/api/NetworkQuery.ts
@@ -1,0 +1,51 @@
+import { useRouter } from "next/router";
+import { EnvironmentNetwork, getEnvironment } from "./Environment";
+
+interface NetworkQueryInterface {
+  /**
+   * @return {EnvironmentNetwork} from query string
+   */
+  getNetwork (): EnvironmentNetwork
+
+  /**
+   * @param {EnvironmentNetwork} network to set to update entire NetworkContext, reflected in url if non env default
+   */
+  setNetwork (network: EnvironmentNetwork): void
+}
+
+/**
+ * @return EnvironmentNetwork if invalid, will be set to `networks[0]`
+ */
+export function useNetworkQuery (): NetworkQueryInterface {
+  const env = getEnvironment()
+  const router = useRouter()
+  const network = resolveNetwork(env.networks, router['network'])
+
+  return {
+    getNetwork (): EnvironmentNetwork {
+      return network
+    },
+    setNetwork (network: EnvironmentNetwork) {
+      if (!env.networks.includes(network)) {
+        throw new Error('network is not part of environment')
+      }
+
+      if (env.networks[0] === network) {
+        void router.push({ pathname: '/' })
+      }
+
+      void router.push({
+        pathname: '/',
+        query: { network: network },
+      })
+    }
+  }
+}
+
+function resolveNetwork (networks: EnvironmentNetwork[], text: string): EnvironmentNetwork {
+  if ((networks as any[]).includes(text)) {
+    return text as EnvironmentNetwork
+  }
+
+  return networks[0]
+}

--- a/src/layouts/contexts/api/NetworkQuery.ts
+++ b/src/layouts/contexts/api/NetworkQuery.ts
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { EnvironmentNetwork, getEnvironment } from "./Environment";
 
 interface NetworkQueryInterface {
@@ -19,7 +20,7 @@ interface NetworkQueryInterface {
 export function useNetworkQuery (): NetworkQueryInterface {
   const env = getEnvironment()
   const router = useRouter()
-  const network = resolveNetwork(env.networks, router['network'])
+  const network = resolveNetwork(router.query['network'])
 
   return {
     getNetwork (): EnvironmentNetwork {
@@ -42,10 +43,59 @@ export function useNetworkQuery (): NetworkQueryInterface {
   }
 }
 
-function resolveNetwork (networks: EnvironmentNetwork[], text: string): EnvironmentNetwork {
-  if ((networks as any[]).includes(text)) {
+/**
+ * Keep Network QueryString when routing
+ */
+export function useKeepNetworkQueryString (): void {
+  const router = useRouter()
+  const { getNetwork } = useNetworkQuery()
+
+  useEffect(() => {
+    function routeChangeComplete (url: string, options: { shadow: boolean }) {
+      if (options.shadow) {
+        return
+      }
+
+      if (hasNetwork(url)) {
+        return
+      }
+
+      if (isDefaultNetwork(getNetwork())) {
+        return
+      }
+
+      void router.replace({
+        pathname: router.pathname,
+        query: {
+          network: getNetwork(),
+          ...router.query
+        },
+      }, undefined, { shallow: true })
+    }
+
+    router.events.on('routeChangeComplete', routeChangeComplete)
+    return () => {
+      router.events.off('routeChangeComplete', routeChangeComplete)
+    }
+  }, [])
+}
+
+function isDefaultNetwork (network: EnvironmentNetwork): boolean {
+  const env = getEnvironment()
+  return env.networks[0] === network
+}
+
+function hasNetwork (url: string): boolean {
+  const query = url.split('?')[1]
+  return new URLSearchParams(query).has('network')
+}
+
+function resolveNetwork (text?: string | string[]): EnvironmentNetwork {
+  const env = getEnvironment()
+
+  if ((env.networks as any[]).includes(text)) {
     return text as EnvironmentNetwork
   }
 
-  return networks[0]
+  return env.networks[0]
 }

--- a/src/layouts/contexts/api/NetworkQuery.ts
+++ b/src/layouts/contexts/api/NetworkQuery.ts
@@ -31,7 +31,7 @@ export function useNetworkQuery (): NetworkQueryInterface {
         throw new Error('network is not part of environment')
       }
 
-      if (env.networks[0] === network) {
+      if (isDefaultNetwork(network)) {
         void router.push({ pathname: '/' })
       }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import '../styles/globals.css'
-import React from "react";
 import Default from "../layouts/Default";
 
 function App ({ Component, pageProps }): JSX.Element {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,8 @@
 import '../styles/globals.css'
+import App, { AppContext } from "next/app";
 import Default from "../layouts/Default";
 
-function App ({ Component, pageProps }): JSX.Element {
+function ExplorerApp ({ Component, pageProps }): JSX.Element {
   return (
     <Default>
       <Component {...pageProps} />
@@ -9,4 +10,12 @@ function App ({ Component, pageProps }): JSX.Element {
   )
 }
 
-export default App
+/**
+ * To load SSR for hydrating
+ */
+ExplorerApp.getInitialProps = async (ctx: AppContext) => {
+  const appProps = await App.getInitialProps(ctx)
+  return { ...appProps }
+}
+
+export default ExplorerApp

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function Home (): JSX.Element {
   return (
     <div className={'container mx-auto px-4 py-6'}>


### PR DESCRIPTION
> Also in this PR, removed `import React from "React"` as it's not required, as suggested by https://github.com/DeFiCh/explorer/pull/40#pullrequestreview-704972162

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

via

```html
<NetworkProvider>
  <Main />
</NetworkProvider>
```

allows

```ts
const { network } = useNetworkContext()
// to access context therefore network
```

#### Supported Contexts

`Context.Provider` are nested properly and will automatically refresh when deeply nested context refreshes.

```jsx
<NetworkProvider>
  <PlaygroundProvider>
    <WhaleProvider>
      <Header />

      <main/>

      <Footer />
    </WhaleProvider>
  </PlaygroundProvider>
</NetworkProvider>
```

```ts
const { network, setNetwork } = useNetworkContext()
```

```ts
const { api, rpc } = usePlaygroundContext()
```

```ts
const api = useWhaleApiClient()
const rpc = useWhaleRpcClient()
```
